### PR TITLE
Fix Log Viewer for Java 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Started as a simple JavaFX test project, but is actually useful as a small and s
 ![screenshot](ivy-log-viewer-screenshot.png)
 
 ## Requirements
-* Java 8 with JavaFX (on Linux you need to install `openjfx` in addition to the JDK).
+* Java 11 with JavaFX SDK installed (on Linux you need to install `openjfx` in addition to the JDK).
+ * Set an environment variable **$JAVA_FX_HOME** pointing to the JavaFX SDK.
 * Maven 3 and later for building.
 
 ## Installation
@@ -16,4 +17,4 @@ Get a built IvyLogViewer from [releases](https://github.com/ivy-supplements/ivy-
 
 ## Run
     cd target/
-    java -jar ivy-log-viewer-X.Y.Z-SNAPSHOT.jar
+    java --module-path $JAVA_FX_HOME/lib --add-modules javafx.controls,javafx.fxml -jar ivy-log-viewer-X.Y.Z-SNAPSHOT.jar

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Started as a simple JavaFX test project, but is actually useful as a small and s
 
 ## Requirements
 * Java 11 with JavaFX SDK installed (on Linux you need to install `openjfx` in addition to the JDK).
- * Set an environment variable **$JAVA_FX_HOME** pointing to the JavaFX SDK.
+    * Set an environment variable **$JAVA_FX_HOME** pointing to the JavaFX SDK.
 * Maven 3 and later for building.
 
 ## Installation

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 	</properties>
 
 	<dependencies>
@@ -31,10 +31,33 @@
 			<version>3.4.1</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+		    <groupId>org.openjfx</groupId>
+		    <artifactId>javafx-base</artifactId>
+		    <version>11</version>
+		</dependency>
+		<dependency>
+		    <groupId>org.openjfx</groupId>
+		    <artifactId>javafx-controls</artifactId>
+		    <version>11</version>
+		</dependency>
+		<dependency>
+		    <groupId>org.openjfx</groupId>
+		    <artifactId>javafx-fxml</artifactId>
+		    <version>11</version>
+		</dependency>
 	</dependencies>
 
 	<build>
 		<plugins>
+		    <plugin>
+		        <groupId>org.openjfx</groupId>
+		        <artifactId>javafx-maven-plugin</artifactId>
+		        <version>0.0.3</version>
+		        <configuration>
+		            <mainClass>com.axonivy.ivy.supplements.logviewer.Main</mainClass>
+		        </configuration>
+		    </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.axonivy.ivy.supplements</groupId>
 	<artifactId>ivy-log-viewer</artifactId>
-	<version>0.9.0</version>
+	<version>0.10.0</version>
 	<packaging>jar</packaging>
 
 	<name>ivy-log-viewer</name>
@@ -50,27 +50,6 @@
 
 	<build>
 		<plugins>
-		    <plugin>
-		        <groupId>org.openjfx</groupId>
-		        <artifactId>javafx-maven-plugin</artifactId>
-		        <version>0.0.3</version>
-		        <configuration>
-		            <mainClass>com.axonivy.ivy.supplements.logviewer.Main</mainClass>
-		        </configuration>
-		    </plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<configuration>
-					<archive>
-						<manifest>
-							<mainClass>com.axonivy.ivy.supplements.logviewer.Main</mainClass>
-						</manifest>
-					</archive>
-					<finalName>ivy-log-viewer</finalName>
-				</configuration>
-			</plugin>
-
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>

--- a/start-scripts/ivy-log-viewer.bat
+++ b/start-scripts/ivy-log-viewer.bat
@@ -1,1 +1,1 @@
-start javaw -jar "ivy-log-viewer.jar"
+start javaw --module-path $JAVA_FX_HOME/lib --add-modules javafx.controls,javafx.fxml -jar "ivy-log-viewer.jar"

--- a/start-scripts/ivy-log-viewer.sh
+++ b/start-scripts/ivy-log-viewer.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-java -jar ivy-log-viewer.jar
+java --module-path $JAVA_FX_HOME/lib --add-modules javafx.controls,javafx.fxml -jar ivy-log-viewer.jar 


### PR DESCRIPTION
Now you must have openfx SDK installed and must have the environment variable **"JAVA_FX_HOME"** set.